### PR TITLE
fix: 删除重复视频和修复图片链接

### DIFF
--- a/docs/2019/04/12.md
+++ b/docs/2019/04/12.md
@@ -8,8 +8,6 @@
 
 [工具] 在 MacOS 的 Touch Bar 上显示 Dock：<https://github.com/pigigaldi/Pock>
 
-[视频] Flutter vs. React Native：<https://www.youtube.com/watch?v=GHNt5Drsaxs>
-
 ### 配图 - Lottie
 ![](https://ws1.sinaimg.cn/large/62bfa70bly1g1zmtvuvu5j20ks14c77g.jpg)
 ![](https://ws1.sinaimg.cn/large/62bfa70bly1g1qezb94uoj20he0gijt8.jpg)

--- a/docs/2019/04/23.md
+++ b/docs/2019/04/23.md
@@ -12,7 +12,7 @@
 ![](https://camo.githubusercontent.com/63886b272799734414ea1beec3005836f3bd3c28/68747470733a2f2f75706c6f61642d696d616765732e6a69616e7368752e696f2f75706c6f61645f696d616765732f333230333834312d663834363839343462363332313131392e6769663f696d6167654d6f6772322f6175746f2d6f7269656e742f7374726970)
 
 ### 配图 - VSCode Quokka
-![](https://quokkajs.com/assets/img/vsc1.gif)
+![](https://quokkajs.com/assets/img/main-video.gif)
 
 ### 配图 - mockit
 ![](https://github.com/boyney123/mockit/raw/master/images/demo.gif)


### PR DESCRIPTION
这段视频已被收录在[2019.4.3的早报](https://github.com/wubaiqing/zaobao/blob/master/docs/2019/04/03.md)中
